### PR TITLE
Set Pokemon ID

### DIFF
--- a/src/components/PokemonForm.js
+++ b/src/components/PokemonForm.js
@@ -7,6 +7,7 @@ function PokemonForm({ handleTrigger, userId }) {
   const [formData, setFormData] = useState({
     name: "",
     hp: "",
+    id: "",
     sprites: {
       front: "",
       back: "",
@@ -18,6 +19,7 @@ function PokemonForm({ handleTrigger, userId }) {
       if (target.name === "front" || target.name === "back") {
         return {
           ...prevData,
+          id: parseInt(target.value.split("/").slice(-1).join().split(".")[0]),
           sprites: {
             ...prevData.sprites,
             [target.name]: target.value,


### PR DESCRIPTION
The front/back image url includes the Pokedex number. We extract that number and use it as the id, so that when we fetch we order the Pokemon based on that id.